### PR TITLE
Any reason why we don't run parent::beforeRender(); ?

### DIFF
--- a/Controller/ForumAppController.php
+++ b/Controller/ForumAppController.php
@@ -153,6 +153,8 @@ class ForumAppController extends AppController {
      * Before render.
      */
     public function beforeRender() {
+        parent::beforeRender();
+
         $this->set('user', $this->Auth->user());
         $this->set('userFields', $this->config['User']['fieldMap']);
         $this->set('userRoutes', $this->config['User']['routes']);


### PR DESCRIPTION
I need it but can work around it if there is a reason for this...
